### PR TITLE
Fix bucket name length.

### DIFF
--- a/0_code_to_s3/s3.tf
+++ b/0_code_to_s3/s3.tf
@@ -2,7 +2,7 @@ resource "random_uuid" "s3_suffix" {
 }
 
 resource "aws_s3_bucket" "source_code_bucket_region_1" {
-  bucket = "gt-s3-arc-code-${random_uuid.s3_suffix.result}-${var.aws_region_1}"
+  bucket = "arc-code-${random_uuid.s3_suffix.result}-${var.aws_region_1}"
   acl    = "private"
   force_destroy = true
   


### PR DESCRIPTION
The bucket name exceeds the maximum length for some regions.
eg: ap-northeast-1